### PR TITLE
fix: Correct Deepgram WebSocket integration

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -114,7 +114,7 @@ document.addEventListener('DOMContentLoaded', () => {
      * Sets up the WebSocket connection to Deepgram for live transcription.
      */
     function setupDeepgramWebSocket() {
-        deepgramSocket = new WebSocket(`wss://api.deepgram.com/v1/listen?encoding=webm&sample_rate=48000`, ['token', DEEPGRAM_KEY]);
+        deepgramSocket = new WebSocket(`wss://api.deepgram.com/v1/listen?encoding=webm&token=${DEEPGRAM_KEY}`);
 
         deepgramSocket.onopen = () => {
             console.log('Deepgram WebSocket opened.');
@@ -155,7 +155,7 @@ document.addEventListener('DOMContentLoaded', () => {
         transcriptionDisplay.textContent = ''; // Clear display
         setupDeepgramWebSocket();
 
-        mediaRecorder = new MediaRecorder(audioStream, { mimeType: 'audio/webm' });
+        mediaRecorder = new MediaRecorder(audioStream, { mimeType: 'audio/webm;codecs=opus' });
 
         mediaRecorder.addEventListener('dataavailable', event => {
             if (event.data.size > 0 && deepgramSocket.readyState === WebSocket.OPEN) {


### PR DESCRIPTION
This hotfix addresses two issues preventing live transcription from working correctly.

- **WebSocket Authentication**: The WebSocket connection URL for Deepgram has been corrected to pass the API key as a `token` query parameter instead of in the `protocol` array.

- **MediaRecorder MIME Type**: The MIME type for the `MediaRecorder` has been updated to `audio/webm;codecs=opus` to align with Deepgram's required audio format and prevent recording errors.

These changes restore the intended live transcription functionality.